### PR TITLE
Dev fix v1.1.0

### DIFF
--- a/Share Extension/Services/FolderDataManager.swift
+++ b/Share Extension/Services/FolderDataManager.swift
@@ -15,6 +15,12 @@ class FolderDataManager {
     func getFolderListDataManager(_ viewcontroller: ShareViewController) {
         let BaseURL = defaults?.string(forKey: "url") ?? ""
         let token = defaults?.string(forKey: "accessToken") ?? ""
+        // 로그아웃 상태일 때
+        if token == "" {
+            viewcontroller.needLogin()
+            return
+        }
+        
         let header: HTTPHeaders = [
             "Authorization": "Bearer " + token,
             "Accept": "application/json"
@@ -30,9 +36,14 @@ class FolderDataManager {
                 viewcontroller.getFolderListAPISuccess(result)
             case .failure(let error):
                 let statusCode = error.responseCode
+                print("FOLDER 가져오기::",statusCode)
                 switch statusCode {
                 case 429:
                     viewcontroller.getFolderListAPIFail()
+                case 401:
+                    RefreshDataManager().refreshDataManager() {
+                        $0 ? FolderDataManager().getFolderListDataManager(viewcontroller) : viewcontroller.uploadItem500Error()
+                    }
                 default:
                     print(error.localizedDescription)
                     print(error.responseCode)

--- a/Share Extension/Services/ShareDataManager.swift
+++ b/Share Extension/Services/ShareDataManager.swift
@@ -15,6 +15,12 @@ class ShareDataManager {
     func getItemDataDataManager(_ url: String, _ viewcontroller: ShareViewController) {
         let BaseURL = defaults?.string(forKey: "url") ?? ""
         let token = defaults?.string(forKey: "accessToken") ?? ""
+        // 로그아웃 상태일 때
+        if token == "" {
+            viewcontroller.needLogin()
+            return
+        }
+        
         let header: HTTPHeaders = [
             "Authorization": "Bearer " + token,
             "Accept": "application/json"
@@ -33,8 +39,11 @@ class ShareDataManager {
                 switch statusCode {
                 case 404:
                     viewcontroller.getItemDataAPIFail()
-//                case 429:
-//                    viewcontroller.getFolderListAPIFail()
+                case 401:
+                    RefreshDataManager().refreshDataManager {
+                        $0 ? viewcontroller.getWebURL() : viewcontroller.getItemDataAPIFail()
+                    }
+                    viewcontroller.getFolderListAPIFail()
                 default:
                     print(error.localizedDescription)
                     print(error.responseCode)

--- a/Share Extension/View/ShareView.swift
+++ b/Share Extension/View/ShareView.swift
@@ -121,7 +121,7 @@ class ShareView: UIView {
             make.trailing.equalToSuperview()
         }
         completeButton.snp.makeConstraints { make in
-            make.height.equalTo(44)
+            make.height.equalTo(48)
             make.leading.trailing.equalToSuperview().inset(16)
             make.bottom.equalToSuperview().offset(-34)
         }

--- a/Share Extension/View/ShareView.swift
+++ b/Share Extension/View/ShareView.swift
@@ -92,6 +92,11 @@ class ShareView: UIView {
             make.leading.trailing.bottom.equalToSuperview()
             make.height.equalTo(317)
         }
+        itemImage.snp.makeConstraints { make in
+            make.width.height.equalTo(80)
+            make.centerX.equalToSuperview()
+            make.centerY.equalTo(backgroundView.snp.top)
+        }
         quitButton.snp.makeConstraints { make in
             make.width.height.equalTo(24)
             make.trailing.equalToSuperview().offset(-16)
@@ -100,20 +105,20 @@ class ShareView: UIView {
         itemNameTextField.snp.makeConstraints { make in
             make.centerX.equalToSuperview()
             make.leading.trailing.equalToSuperview().inset(16)
-            make.top.equalToSuperview().offset(50)
+            make.top.equalTo(itemImage.snp.bottom).offset(16)
         }
         itemPriceTextField.snp.makeConstraints { make in
             make.centerX.equalToSuperview()
-            make.top.equalTo(itemNameTextField.snp.bottom).offset(2)
+            make.top.equalTo(itemNameTextField.snp.bottom).offset(6)
         }
         setNotificationButton.snp.makeConstraints { make in
             make.centerX.equalToSuperview()
-            make.top.equalTo(itemPriceTextField.snp.bottom).offset(12)
+            make.top.equalTo(itemPriceTextField.snp.bottom).offset(16)
         }
         addFolderButton.snp.makeConstraints { make in
             make.width.height.equalTo(80)
             make.leading.equalToSuperview().offset(16)
-            make.top.equalTo(setNotificationButton.snp.bottom).offset(15)
+            make.top.equalTo(setNotificationButton.snp.bottom).offset(16)
         }
         folderCollectionView.snp.makeConstraints { make in
             make.leading.equalTo(addFolderButton.snp.trailing).offset(10)
@@ -123,13 +128,9 @@ class ShareView: UIView {
         completeButton.snp.makeConstraints { make in
             make.height.equalTo(48)
             make.leading.trailing.equalToSuperview().inset(16)
+            make.top.equalTo(addFolderButton.snp.bottom).offset(16)
             make.bottom.equalToSuperview().offset(-34)
-        }
-        
-        itemImage.snp.makeConstraints { make in
-            make.width.height.equalTo(80)
-            make.centerX.equalToSuperview()
-            make.centerY.equalTo(backgroundView.snp.top)
+//            make.bottom.greaterThanOrEqualToSuperview().offset(-34)
         }
     }
 }

--- a/Share Extension/ViewControllers/NotificationSettingViewController.swift
+++ b/Share Extension/ViewControllers/NotificationSettingViewController.swift
@@ -100,7 +100,7 @@ class NotificationSettingViewController: UIViewController {
             make.top.equalTo(notificationPickerView.snp.bottom).offset(43)
         }
         completeButton.snp.makeConstraints { make in
-            make.height.equalTo(44)
+            make.height.equalTo(48)
             make.leading.trailing.equalToSuperview().inset(16)
             make.top.equalTo(message.snp.bottom).offset(16)
         }

--- a/Share Extension/ViewControllers/NotificationSettingViewController.swift
+++ b/Share Extension/ViewControllers/NotificationSettingViewController.swift
@@ -24,7 +24,9 @@ class NotificationSettingViewController: UIViewController {
         $0.setTypoStyleWithSingleLine(typoStyle: .SuitD3)
         $0.textColor = .gray_200
     }
-    let completeButton = DefaultButton(titleStr: Button.complete)
+    let completeButton = DefaultButton(titleStr: Button.complete).then{
+        $0.isActivate = true
+    }
     // MARK: - Life Cycles
     var notiType: String?
     var dateAndTime: String?
@@ -77,8 +79,8 @@ class NotificationSettingViewController: UIViewController {
         self.view.addSubview(titleLabel)
         self.view.addSubview(exitBtn)
         self.view.addSubview(notificationPickerView)
-        self.view.addSubview(message)
         self.view.addSubview(completeButton)
+        self.view.addSubview(message)
     }
     func setUpConstraint() {
         titleLabel.snp.makeConstraints { make in
@@ -92,17 +94,17 @@ class NotificationSettingViewController: UIViewController {
         }
         notificationPickerView.snp.makeConstraints { make in
             make.leading.trailing.equalToSuperview().inset(16)
-            make.top.equalTo(titleLabel.snp.bottom).offset(65)
+            make.top.equalTo(titleLabel.snp.bottom).offset(51.5)
             make.height.equalTo(100)
-        }
-        message.snp.makeConstraints { make in
-            make.leading.equalTo(notificationPickerView)
-            make.top.equalTo(notificationPickerView.snp.bottom).offset(43)
         }
         completeButton.snp.makeConstraints { make in
             make.height.equalTo(48)
             make.leading.trailing.equalToSuperview().inset(16)
-            make.top.equalTo(message.snp.bottom).offset(16)
+            make.top.equalToSuperview().offset(235)
+        }
+        message.snp.makeConstraints { make in
+            make.centerX.equalToSuperview()
+            make.bottom.equalTo(completeButton.snp.top).offset(-6)
         }
     }
     // MARK: - Actions

--- a/Share Extension/ViewControllers/ShareViewController.swift
+++ b/Share Extension/ViewControllers/ShareViewController.swift
@@ -51,10 +51,6 @@ class ShareViewController: UIViewController {
         
         self.selectedFolderIdx = -1
         setUpShareView()
-        
-        DispatchQueue.main.async {
-            self.getWebURL()
-        }
     }
     override func viewDidAppear(_ animated: Bool) {
         // Network Check
@@ -63,12 +59,12 @@ class ShareViewController: UIViewController {
         let defaults = UserDefaults(suiteName: "group.gomin.Wishboard.Share")
         let token = defaults?.string(forKey: "accessToken") ?? ""
         if token == "" {
-            shareView.completeButton.isActivate = false
-            shareView.itemNameTextField.isEnabled = false
-            shareView.itemPriceTextField.isEnabled = false
-            shareView.setNotificationButton.isEnabled = false
-            shareView.addFolderButton.isEnabled = false
+            needLogin()
             return
+        } else {
+            DispatchQueue.main.async {
+                self.getWebURL()
+            }
         }
     }
     override func viewWillAppear(_ animated: Bool) {
@@ -268,6 +264,13 @@ extension ShareViewController: UICollectionViewDelegate, UICollectionViewDataSou
 }
 // MARK: - API Success
 extension ShareViewController {
+    func needLogin() {
+        shareView.completeButton.needLoginButton()
+        shareView.itemNameTextField.isEnabled = false
+        shareView.itemPriceTextField.isEnabled = false
+        shareView.setNotificationButton.isEnabled = false
+        shareView.addFolderButton.isEnabled = false
+    }
     // MARK: 폴더 리스트 조회 API
     func getFolderListAPISuccess(_ result: [FolderListModel]) {
         self.folderListData = result
@@ -279,6 +282,8 @@ extension ShareViewController {
     }
     // MARK: 아이템 정보 파싱
     func getItemDataAPISuccess(_ result: APIModel<ItemParsingModel>) {
+//        print("get item Data: ", result)
+        
         if let itemImg = result.data?.item_img.nilIfEmpty {self.itemImg = itemImg}
         if let itemName = result.data?.item_name.nilIfEmpty {self.itemName = itemName}
         if let itemPrice = result.data?.item_price.nilIfEmpty {self.itemPrice = itemPrice}
@@ -317,6 +322,8 @@ extension ShareViewController {
         if result.success {
             uploadItemAPIFunc()
         } else {
+            // 500일때 뿐만 아니라 다른 이슈일 때도 에러바 출력
+            // 401 일때도
             uploadItem500Error()
         }
         print("아이템 등록 🔥", result.message)

--- a/Wishboard.xcodeproj/project.pbxproj
+++ b/Wishboard.xcodeproj/project.pbxproj
@@ -114,7 +114,6 @@
 		236FE93A28DF85A4006142DB /* SetNotificationDate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2350FADE28DB9BEA00981B8F /* SetNotificationDate.swift */; };
 		236FE93B28DF85A7006142DB /* Observable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23D5518828C6B02400D81B5F /* Observable.swift */; };
 		236FE93C28DF85AA006142DB /* String.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23D5518A28C6B45C00D81B5F /* String.swift */; };
-		236FE93D28DF85B0006142DB /* PopUpDeleteUserViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23E378DD28D2EBFA00C52F2D /* PopUpDeleteUserViewController.swift */; };
 		236FE93E28DF85B0006142DB /* PopUpViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2374789D28D1EDF600CF941A /* PopUpViewController.swift */; };
 		236FE94028DF85B3006142DB /* APIModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23C3113628DF633D00A636F6 /* APIModel.swift */; };
 		236FE94228DF888A006142DB /* FolderCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 236FE94128DF888A006142DB /* FolderCollectionViewCell.swift */; };
@@ -1816,7 +1815,6 @@
 				23B885EC28E5A9B400142FFA /* UploadItemInput.swift in Sources */,
 				23CBAFDC28DFDF8500B41513 /* NewFolderViewController.swift in Sources */,
 				236FE91F28DF8592006142DB /* UIView.swift in Sources */,
-				236FE93D28DF85B0006142DB /* PopUpDeleteUserViewController.swift in Sources */,
 				2364B7AA29D41E1F006459EF /* TitleCenterViewController.swift in Sources */,
 				236FE91E28DF8592006142DB /* UIBezierPath.swift in Sources */,
 				236FE93C28DF85AA006142DB /* String.swift in Sources */,

--- a/Wishboard.xcodeproj/project.pbxproj
+++ b/Wishboard.xcodeproj/project.pbxproj
@@ -150,6 +150,9 @@
 		23A85F8528E3AE6200075667 /* LostPasswordInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23A85F8428E3AE6200075667 /* LostPasswordInput.swift */; };
 		23AADBC128DF8F9800AB75C6 /* NotificationSettingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23AADBC028DF8F9800AB75C6 /* NotificationSettingViewController.swift */; };
 		23B1FA4B294017F200832425 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 23B1FA4D294017F200832425 /* InfoPlist.strings */; };
+		23B351842A6CF74200FD7A14 /* RefreshDataManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23134D3E29B222BF00238536 /* RefreshDataManager.swift */; };
+		23B351852A6CF9D600FD7A14 /* RefreshInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23134D3C29B2216700238536 /* RefreshInput.swift */; };
+		23B351862A6CF9DE00FD7A14 /* Storage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 236AC9EF291A6AB700E1474C /* Storage.swift */; };
 		23B885EC28E5A9B400142FFA /* UploadItemInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = 233CDED228E4FE0A004E12BC /* UploadItemInput.swift */; };
 		23BB603528E2709C007EA1EF /* ModifyProfileInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23BB603428E2709C007EA1EF /* ModifyProfileInput.swift */; };
 		23BDC2452944E7B1004338E0 /* Optional.swift in Sources */ = {isa = PBXBuildFile; fileRef = 239422E5292FEFCB0024CEBD /* Optional.swift */; };
@@ -1795,13 +1798,16 @@
 				23E0ACC828E7B563008C35C2 /* KeyboardViewController.swift in Sources */,
 				235129DA28F67BAE00489CAD /* BottomSheetKeyboardViewController.swift in Sources */,
 				23F1F21C293D7E7D0074C4D0 /* UILabel.swift in Sources */,
+				23B351852A6CF9D600FD7A14 /* RefreshInput.swift in Sources */,
 				233C34B229C73E2F005DFA39 /* DefaultButton.swift in Sources */,
 				236FE94028DF85B3006142DB /* APIModel.swift in Sources */,
+				23B351862A6CF9DE00FD7A14 /* Storage.swift in Sources */,
 				230192BC2A3068C200B30B0E /* DefaultLabel.swift in Sources */,
 				236FE91128DF83E6006142DB /* UIFont.swift in Sources */,
 				230180E928E50C0B001034FC /* FolderInput.swift in Sources */,
 				236FE93A28DF85A4006142DB /* SetNotificationDate.swift in Sources */,
 				23BDC2452944E7B1004338E0 /* Optional.swift in Sources */,
+				23B351842A6CF74200FD7A14 /* RefreshDataManager.swift in Sources */,
 				236FE92128DF8592006142DB /* UIColor.swift in Sources */,
 				2351859A29A6F8540004FCB4 /* Image.swift in Sources */,
 				235D550728EBD2CE00314D62 /* ItemParsingModel.swift in Sources */,

--- a/Wishboard/domain/Cells/Calender/CalenderTableViewCell.swift
+++ b/Wishboard/domain/Cells/Calender/CalenderTableViewCell.swift
@@ -59,8 +59,9 @@ class CalenderTableViewCell: UITableViewCell {
             $0.appearance.todaySelectionColor = .green_500
             $0.appearance.titleSelectionColor = .gray_700
             
-            $0.appearance.eventDefaultColor = .green_200
-            $0.appearance.eventSelectionColor = .green_500
+            // 이벤트가 있는 날짜는 투명도가 높은 green색이 덧씌워진다.
+            $0.appearance.eventDefaultColor = .green_alpha
+            $0.appearance.eventSelectionColor = .green_alpha
         }
         contentView.addSubview(calender)
         contentView.addSubview(backButton)

--- a/Wishboard/domain/Cells/Calender/CalenderTableViewCell.swift
+++ b/Wishboard/domain/Cells/Calender/CalenderTableViewCell.swift
@@ -49,8 +49,8 @@ class CalenderTableViewCell: UITableViewCell {
             $0.appearance.headerTitleColor = .gray_700
             $0.appearance.weekdayTextColor = .gray_700
             $0.appearance.headerTitleFont = TypoStyle.MontserratH1.font
-            $0.appearance.titleFont = TypoStyle.SuitD1.font
-            $0.appearance.weekdayFont = TypoStyle.MontserratB2.font
+            $0.appearance.titleFont = TypoStyle.SuitD1.font   // 날(1...31일) 폰트
+            $0.appearance.weekdayFont = TypoStyle.MontserratB2.font       // 상단 월화수목금 폰트
             $0.appearance.subtitleFont = TypoStyle.SuitH3.font
             
             $0.appearance.todayColor = .green_500

--- a/Wishboard/domain/Cells/Cart/CartTableViewCell.swift
+++ b/Wishboard/domain/Cells/Cart/CartTableViewCell.swift
@@ -27,6 +27,9 @@ class CartTableViewCell: UITableViewCell {
         config.contentInsets = NSDirectionalEdgeInsets(top: 10, leading: 10, bottom: 10, trailing: 10)
         $0.configuration = config
     }
+    let cartCountStack = UIStackView().then {
+        $0.axis = .horizontal
+    }
     let minusButton = UIButton().then{
         var config = UIButton.Configuration.plain()
         config.image = Image.cartMinus
@@ -40,8 +43,8 @@ class CartTableViewCell: UITableViewCell {
         $0.configuration = config
     }
     let countLabel = DefaultLabel().then{
-        $0.textAlignment = .center
         $0.setTypoStyleWithSingleLine(typoStyle: .SuitD2)
+        $0.textAlignment = .center
     }
     let priceLabel = DefaultLabel().then{
         $0.setTypoStyleWithSingleLine(typoStyle: .MontserratH2)
@@ -64,9 +67,12 @@ class CartTableViewCell: UITableViewCell {
     func setUpView() {
         contentView.addSubview(itemImage)
         contentView.addSubview(deleteButton)
-        contentView.addSubview(minusButton)
-        contentView.addSubview(plusButton)
-        contentView.addSubview(countLabel)
+        
+        contentView.addSubview(cartCountStack)
+        cartCountStack.addArrangedSubview(minusButton)
+        cartCountStack.addArrangedSubview(countLabel)
+        cartCountStack.addArrangedSubview(plusButton)
+        
         contentView.addSubview(priceLabel)
         contentView.addSubview(won)
         contentView.addSubview(itemName)
@@ -79,23 +85,21 @@ class CartTableViewCell: UITableViewCell {
         }
         deleteButton.snp.makeConstraints { make in
             make.width.height.equalTo(44)
-            make.top.equalTo(itemImage.snp.top).offset(-10)
-            make.trailing.equalToSuperview().offset(-9)
+            make.top.equalToSuperview().offset(6)
+            make.trailing.equalToSuperview().offset(-2)
+        }
+        cartCountStack.snp.makeConstraints { make in
+            make.leading.equalTo(itemImage.snp.trailing)
+            make.bottom.equalTo(itemImage.snp.bottom).offset(10)
         }
         minusButton.snp.makeConstraints { make in
             make.width.height.equalTo(44)
-            make.bottom.equalTo(itemImage.snp.bottom).offset(10)
-            make.leading.equalTo(itemImage.snp.trailing)
         }
         countLabel.snp.makeConstraints { make in
             make.width.equalTo(20)
-            make.centerY.equalTo(minusButton)
-            make.leading.equalTo(minusButton.snp.trailing)
         }
         plusButton.snp.makeConstraints { make in
             make.width.height.equalTo(44)
-            make.centerY.equalTo(countLabel)
-            make.leading.equalTo(countLabel.snp.trailing)
         }
         won.snp.makeConstraints { make in
             make.trailing.equalToSuperview().offset(-10)
@@ -106,10 +110,9 @@ class CartTableViewCell: UITableViewCell {
             make.centerY.equalTo(won)
         }
         itemName.snp.makeConstraints { make in
-            make.top.equalTo(itemImage.snp.top).offset(5)
+            make.top.equalTo(itemImage.snp.top)
             make.leading.equalTo(itemImage.snp.trailing).offset(10)
             make.trailing.equalTo(deleteButton.snp.leading)
-//            make.bottom.lessThanOrEqualTo(minusButton.snp.top).offset(-10)
         }
     }
 }

--- a/Wishboard/domain/Cells/Item/ItemDetailTableViewCell.swift
+++ b/Wishboard/domain/Cells/Item/ItemDetailTableViewCell.swift
@@ -50,6 +50,7 @@ class ItemDetailTableViewCell: UITableViewCell {
         $0.backgroundColor = .gray_100
     }
     let memoTitlelabel = DefaultLabel().then{
+        $0.text = Title.memo
         $0.setTypoStyleWithSingleLine(typoStyle: .SuitB2)
     }
     let memoContentLabel = DefaultLabel().then{

--- a/Wishboard/domain/Cells/Item/UploadItemBottomSheetTableViewCell.swift
+++ b/Wishboard/domain/Cells/Item/UploadItemBottomSheetTableViewCell.swift
@@ -11,7 +11,7 @@ class UploadItemBottomSheetTableViewCell: UITableViewCell {
     let subTitle = UILabel().then{
         $0.text = Message.shoppingLink
         $0.setTypoStyleWithSingleLine(typoStyle: .SuitB3)
-        $0.textColor = .green_500
+        $0.textColor = .green_700
         $0.isHidden = true
     }
     //MARK: - Life Cycles

--- a/Wishboard/domain/Cells/Mypage/MypageProfileTableViewCell.swift
+++ b/Wishboard/domain/Cells/Mypage/MypageProfileTableViewCell.swift
@@ -28,6 +28,7 @@ class MypageProfileTableViewCell: UITableViewCell {
         $0.setTitleColor(UIColor.gray_600, for: .normal)
         $0.titleLabel?.setTypoStyleWithSingleLine(typoStyle: .SuitB3)
         $0.backgroundColor = UIColor.gray_100
+        $0.titleEdgeInsets = UIEdgeInsets(top: 4, left: 10, bottom: 4, right: 10)
         
         $0.clipsToBounds = true
         $0.layer.cornerRadius = 12

--- a/Wishboard/domain/Cells/OnBoarding/OnBoardingTableViewCell.swift
+++ b/Wishboard/domain/Cells/OnBoarding/OnBoardingTableViewCell.swift
@@ -110,7 +110,7 @@ class OnBoardingTableViewCell: UITableViewCell {
             make.leading.equalTo(accountExistButton.snp.trailing).offset(5)
         }
         self.registerButton.snp.makeConstraints { make in
-            make.height.equalTo(50)
+            make.height.equalTo(48)
             make.centerX.equalToSuperview()
             make.leading.equalToSuperview().offset(16)
             make.trailing.equalToSuperview().offset(-16)

--- a/Wishboard/domain/Services/Authentication/RefreshDataManager.swift
+++ b/Wishboard/domain/Services/Authentication/RefreshDataManager.swift
@@ -12,7 +12,6 @@ class RefreshDataManager {
     //MARK: Refresh
     func refreshDataManager(completion: @escaping (Bool) -> Void) {
         let parameter = RefreshInput(refreshToken: UserDefaults.standard.string(forKey: "refreshToken") ?? "")
-        print("refresh token:", parameter)
         AF.request(Storage().BaseURL + "/auth/refresh",
                    method: .post,
                    parameters: parameter,

--- a/Wishboard/domain/Services/Mypage/MypageDataManager.swift
+++ b/Wishboard/domain/Services/Mypage/MypageDataManager.swift
@@ -99,7 +99,7 @@ class MypageDataManager {
         }
     }
     // MARK: - 회원 탈퇴
-    func deleteUserDataManager(_ viewcontroller: MyPageViewController) {
+    func deleteUserDataManager(_ viewcontroller: PopUpDeleteUserViewController) {
         AF.request(Storage().BaseURL + "/user",
                            method: .delete,
                            parameters: nil,

--- a/Wishboard/domain/ViewControllers/Item/UploadItem/NotificationSettingViewController.swift
+++ b/Wishboard/domain/ViewControllers/Item/UploadItem/NotificationSettingViewController.swift
@@ -108,7 +108,7 @@ class NotificationSettingViewController: UIViewController {
             make.top.equalTo(notificationPickerView.snp.bottom).offset(43)
         }
         completeButton.snp.makeConstraints { make in
-            make.height.equalTo(44)
+            make.height.equalTo(48)
             make.leading.trailing.equalToSuperview().inset(16)
             make.top.equalTo(message.snp.bottom).offset(16)
         }

--- a/Wishboard/domain/ViewControllers/Item/UploadItem/NotificationSettingViewController.swift
+++ b/Wishboard/domain/ViewControllers/Item/UploadItem/NotificationSettingViewController.swift
@@ -22,7 +22,7 @@ class NotificationSettingViewController: UIViewController {
     let message = UILabel().then{
         $0.text = Message.itemNotification
         $0.setTypoStyleWithSingleLine(typoStyle: .SuitD3)
-        $0.textColor = .gray_200
+        $0.textColor = .gray_300
     }
     let completeButton = DefaultButton(titleStr: Button.complete).then{
         $0.isActivate = true
@@ -85,8 +85,8 @@ class NotificationSettingViewController: UIViewController {
         self.view.addSubview(titleLabel)
         self.view.addSubview(exitBtn)
         self.view.addSubview(notificationPickerView)
-        self.view.addSubview(message)
         self.view.addSubview(completeButton)
+        self.view.addSubview(message)
     }
     func setUpConstraint() {
         titleLabel.snp.makeConstraints { make in
@@ -100,17 +100,17 @@ class NotificationSettingViewController: UIViewController {
         }
         notificationPickerView.snp.makeConstraints { make in
             make.leading.trailing.equalToSuperview().inset(16)
-            make.top.equalTo(titleLabel.snp.bottom).offset(65)
+            make.top.equalTo(titleLabel.snp.bottom).offset(51.5)
             make.height.equalTo(100)
-        }
-        message.snp.makeConstraints { make in
-            make.leading.equalTo(notificationPickerView)
-            make.top.equalTo(notificationPickerView.snp.bottom).offset(43)
         }
         completeButton.snp.makeConstraints { make in
             make.height.equalTo(48)
             make.leading.trailing.equalToSuperview().inset(16)
-            make.top.equalTo(message.snp.bottom).offset(16)
+            make.top.equalToSuperview().offset(235)
+        }
+        message.snp.makeConstraints { make in
+            make.centerX.equalToSuperview()
+            make.bottom.equalTo(completeButton.snp.top).offset(-6)
         }
     }
     // MARK: - Actions

--- a/Wishboard/domain/ViewControllers/Mypage/ModifyProfileViewController.swift
+++ b/Wishboard/domain/ViewControllers/Mypage/ModifyProfileViewController.swift
@@ -121,13 +121,13 @@ extension ModifyProfileViewController {
             make.centerX.equalToSuperview()
         }
         completeButton.snp.makeConstraints { make in
-            make.height.equalTo(50)
+            make.height.equalTo(48)
             make.leading.trailing.equalToSuperview().inset(16)
             make.centerX.equalToSuperview()
             make.bottom.equalToSuperview().offset(-34)
         }
         completeKeyboardButton.snp.makeConstraints { make in
-            make.height.equalTo(50)
+            make.height.equalTo(48)
             make.leading.trailing.equalToSuperview().inset(16)
             make.centerX.equalToSuperview()
             make.bottom.equalToSuperview().offset(-16)

--- a/Wishboard/domain/ViewControllers/Mypage/MyPageViewController.swift
+++ b/Wishboard/domain/ViewControllers/Mypage/MyPageViewController.swift
@@ -215,17 +215,10 @@ extension MyPageViewController {
         let dialog = PopUpDeleteUserViewController(titleText: "회원 탈퇴", greenBtnText: "취소", blackBtnText: "탈퇴", placeholder: Placeholder.email, email: email)
         dialog.modalPresentationStyle = .overFullScreen
         self.present(dialog, animated: false, completion: nil)
-        
-        dialog.okBtn.addTarget(self, action: #selector(signOutButtonDidTap), for: .touchUpInside)
     }
     @objc func logoutButtonDidTap() {
         self.dismiss(animated: false)
         MypageDataManager().logoutDataManager(self)
-        UIDevice.vibrate()
-    }
-    @objc func signOutButtonDidTap() {
-        self.dismiss(animated: false)
-        MypageDataManager().deleteUserDataManager(self)
         UIDevice.vibrate()
     }
 }
@@ -319,22 +312,6 @@ extension MyPageViewController {
     // MARK: 알림 토글 수정 API
     func switchNotificationAPISuccess(_ result: APIModel<TokenResultModel>) {
         pushState?.toggle()
-        print(result.message)
-    }
-    // MARK: 회원 탈퇴 API
-    func deleteUserAPISuccess(_ result: APIModel<TokenResultModel>) {
-        // delete UserInfo
-        UserDefaults.standard.removeObject(forKey: "accessToken")
-        UserDefaults.standard.removeObject(forKey: "refreshToken")
-        UserDefaults.standard.removeObject(forKey: "email")
-        UserDefaults.standard.removeObject(forKey: "password")
-        UserDefaults.standard.removeObject(forKey: "isFirstLogin")
-        UserDefaults(suiteName: "group.gomin.Wishboard.Share")?.removeObject(forKey: "accessToken")
-        
-        let onboardingVC = OnBoardingViewController()
-        onboardingVC.deleteUser = true
-        self.navigationController?.pushViewController(onboardingVC, animated: true)
-        
         print(result.message)
     }
     // MARK: 로그아웃 API

--- a/Wishboard/domain/Views/Authentication/Login/LoginView.swift
+++ b/Wishboard/domain/Views/Authentication/Login/LoginView.swift
@@ -103,7 +103,7 @@ class LoginView: UIView {
             make.bottom.equalToSuperview().offset(-34)
         }
         self.loginButton.snp.makeConstraints { make in
-            make.height.equalTo(50)
+            make.height.equalTo(48)
             make.leading.trailing.equalToSuperview().inset(16)
             make.centerX.equalToSuperview()
             make.bottom.equalTo(lostPasswordButton.snp.top).offset(-16)
@@ -116,7 +116,7 @@ class LoginView: UIView {
             make.bottom.equalToSuperview().offset(-16)
         }
         self.loginButtonKeyboard.snp.makeConstraints { make in
-            make.height.equalTo(50)
+            make.height.equalTo(48)
             make.leading.trailing.equalToSuperview().inset(16)
             make.centerX.equalToSuperview()
             make.bottom.equalTo(lostPasswordButtonKeyboard.snp.top).offset(-16)

--- a/Wishboard/domain/Views/Authentication/Login/LoginView.swift
+++ b/Wishboard/domain/Views/Authentication/Login/LoginView.swift
@@ -34,7 +34,7 @@ class LoginView: UIView {
     }
     // 비밀번호를 잊으셨나요?
     let lostPasswordButton = UIButton().then{
-        $0.setUnderline(Button.lostPassword, UIColor.systemGray)
+        $0.setUnderline(Button.lostPassword, .gray_300, TypoStyle.SuitB3.font)
     }
     // 키보드 위 Accessory
     lazy var accessoryView: UIView = {

--- a/Wishboard/domain/Views/Authentication/LostPassword/GetEmailView.swift
+++ b/Wishboard/domain/Views/Authentication/LostPassword/GetEmailView.swift
@@ -90,7 +90,7 @@ class GetEmailView: UIView {
             make.top.equalTo(codeTextField.snp.bottom).offset(6)
         }
         loginButton.snp.makeConstraints { make in
-            make.height.equalTo(44)
+            make.height.equalTo(48)
             make.leading.trailing.equalToSuperview().inset(16)
             make.centerX.equalToSuperview()
             make.bottom.equalToSuperview().inset(16)

--- a/Wishboard/domain/Views/Authentication/LostPassword/LostPasswordView.swift
+++ b/Wishboard/domain/Views/Authentication/LostPassword/LostPasswordView.swift
@@ -74,7 +74,7 @@ class LostPasswordView: UIView {
         }
         getEmailButton.snp.makeConstraints { make in
             make.leading.trailing.equalToSuperview().inset(16)
-            make.height.equalTo(44)
+            make.height.equalTo(48)
             make.bottom.equalToSuperview().inset(16)
         }
     }

--- a/Wishboard/domain/Views/Authentication/ModifyPassword/ModifyPasswordView.swift
+++ b/Wishboard/domain/Views/Authentication/ModifyPassword/ModifyPasswordView.swift
@@ -18,7 +18,7 @@ class ModifyPasswordView: UIView {
         $0.setTypoStyleWithSingleLine(typoStyle: .SuitB3)
     }
     // 새 비밀번호 TextField
-    let newPasswordTextField = DefaultTextField(Placeholder.email).then{
+    let newPasswordTextField = DefaultTextField(Placeholder.newPassword).then{
         $0.isSecureTextEntry = true
     }
     let newPasswordErrorMessageLabel = UILabel().then{
@@ -33,7 +33,7 @@ class ModifyPasswordView: UIView {
         $0.setTypoStyleWithSingleLine(typoStyle: .SuitB3)
     }
     // 비밀번호 재입력 TextField
-    let passwordRewriteTextField = DefaultTextField(Placeholder.password).then{
+    let passwordRewriteTextField = DefaultTextField(Placeholder.rewritePassword).then{
         $0.isSecureTextEntry = true
     }
     let passwordRewriteErrorMessageLabel = UILabel().then{

--- a/Wishboard/domain/Views/Authentication/ModifyPassword/ModifyPasswordView.swift
+++ b/Wishboard/domain/Views/Authentication/ModifyPassword/ModifyPasswordView.swift
@@ -113,14 +113,14 @@ class ModifyPasswordView: UIView {
             make.top.equalTo(passwordRewriteTextField.snp.bottom).offset(6)
         }
         self.completeButton.snp.makeConstraints { make in
-            make.height.equalTo(50)
+            make.height.equalTo(48)
             make.leading.trailing.equalToSuperview().inset(16)
             make.centerX.equalToSuperview()
             make.bottom.equalToSuperview().offset(-34)
         }
         // keyboard button
         self.completeButtonKeyboard.snp.makeConstraints { make in
-            make.height.equalTo(50)
+            make.height.equalTo(48)
             make.leading.trailing.equalToSuperview().inset(20)
             make.centerX.equalToSuperview()
             make.bottom.equalToSuperview().offset(-16)

--- a/Wishboard/domain/Views/Authentication/Register/RegisterEmailView.swift
+++ b/Wishboard/domain/Views/Authentication/Register/RegisterEmailView.swift
@@ -74,7 +74,7 @@ class RegisterEmailView: UIView {
         }
         nextButton.snp.makeConstraints { make in
             make.leading.trailing.equalToSuperview().inset(16)
-            make.height.equalTo(44)
+            make.height.equalTo(48)
             make.bottom.equalToSuperview().inset(16)
         }
     }

--- a/Wishboard/domain/Views/Authentication/Register/RegisterPasswordView.swift
+++ b/Wishboard/domain/Views/Authentication/Register/RegisterPasswordView.swift
@@ -88,7 +88,7 @@ class RegisterPasswordView: UIView {
         }
         registerButton.snp.makeConstraints { make in
             make.leading.trailing.equalToSuperview().inset(16)
-            make.height.equalTo(44)
+            make.height.equalTo(48)
             make.bottom.equalToSuperview().inset(16)
         }
         stack.snp.makeConstraints { make in

--- a/Wishboard/domain/Views/Authentication/Register/RegisterPasswordView.swift
+++ b/Wishboard/domain/Views/Authentication/Register/RegisterPasswordView.swift
@@ -94,7 +94,7 @@ class RegisterPasswordView: UIView {
         stack.snp.makeConstraints { make in
             make.leading.greaterThanOrEqualToSuperview().offset(16)
             make.trailing.lessThanOrEqualToSuperview().offset(-16)
-            make.bottom.equalTo(registerButton.snp.top).offset(-5)
+            make.bottom.equalTo(registerButton.snp.top).offset(-6)
             make.centerX.equalToSuperview()
         }
     }

--- a/Wishboard/domain/Views/Home/HomeBottomSheetView.swift
+++ b/Wishboard/domain/Views/Home/HomeBottomSheetView.swift
@@ -71,7 +71,7 @@ class HomeBottomSheetView: UIView {
             make.height.equalTo(590)
         }
         okButton.snp.makeConstraints { make in
-            make.height.equalTo(50)
+            make.height.equalTo(48)
             make.leading.trailing.equalToSuperview().inset(16)
             make.top.equalTo(howToCollectionView.snp.bottom).offset(16)
         }

--- a/Wishboard/domain/Views/Item/UploadItem/UploadItemView.swift
+++ b/Wishboard/domain/Views/Item/UploadItem/UploadItemView.swift
@@ -24,6 +24,7 @@ class UploadItemView: UIView {
     var saveButton = DefaultButton(titleStr: Button.save).then{
         $0.isActivate = true
         $0.layer.cornerRadius = 15
+        $0.titleLabel?.setTypoStyleWithSingleLine(typoStyle: .SuitB3)
     }
     
     let scrollView = UIScrollView().then{

--- a/Wishboard/global/UI/Default/DefaultButton.swift
+++ b/Wishboard/global/UI/Default/DefaultButton.swift
@@ -92,4 +92,10 @@ class DefaultButton: UIButton {
         self.lottieView.isHidden = true
         self.titleLabel?.isHidden = false
     }
+    func needLoginButton() {
+        setTitle(Button.doLogin, for: .normal)
+        backgroundColor = UIColor.gray_100
+        setTitleColor(UIColor.gray_300, for: .normal)
+        isEnabled = false
+    }
 }

--- a/Wishboard/global/UI/Fonts/TypoStyle.swift
+++ b/Wishboard/global/UI/Fonts/TypoStyle.swift
@@ -83,8 +83,8 @@ extension TypoStyle {
             case .MontserratH1:            return FontDescription(font: .Montserrat, style: .ExtraBold, size: 20)
             case .MontserratH2:            return FontDescription(font: .Montserrat, style: .ExtraBold, size: 18)
             case .MontserratH3:            return FontDescription(font: .Montserrat, style: .ExtraBold, size: 14)
-            case .MontserratB1:            return FontDescription(font: .Montserrat, style: .SemiBold, size: 16)
-            case .MontserratB2:            return FontDescription(font: .Montserrat, style: .Medium, size: 16)
+            case .MontserratB1:            return FontDescription(font: .Montserrat, style: .SemiBold, size: 14)
+            case .MontserratB2:            return FontDescription(font: .Montserrat, style: .Medium, size: 14)
             case .MontserratD1:            return FontDescription(font: .Montserrat, style: .Regular, size: 9)
         }
     }

--- a/Wishboard/global/UI/Fonts/TypoStyle.swift
+++ b/Wishboard/global/UI/Fonts/TypoStyle.swift
@@ -84,7 +84,7 @@ extension TypoStyle {
             case .MontserratH2:            return FontDescription(font: .Montserrat, style: .ExtraBold, size: 18)
             case .MontserratH3:            return FontDescription(font: .Montserrat, style: .ExtraBold, size: 14)
             case .MontserratB1:            return FontDescription(font: .Montserrat, style: .SemiBold, size: 14)
-            case .MontserratB2:            return FontDescription(font: .Montserrat, style: .Medium, size: 14)
+            case .MontserratB2:            return FontDescription(font: .Montserrat, style: .Regular, size: 14)
             case .MontserratD1:            return FontDescription(font: .Montserrat, style: .Regular, size: 9)
         }
     }

--- a/Wishboard/global/UI/Namespace/StringEnum.swift
+++ b/Wishboard/global/UI/Namespace/StringEnum.swift
@@ -22,6 +22,10 @@ enum Placeholder {
     public static let shareItemName = "상품명을 입력해 주세요."
     public static let shareItemPrice = "가격을 입력해 주세요."
     
+    // MARK: Modify Password
+    public static let newPassword = "새 비밀번호를 입력해 주세요."
+    public static let rewritePassword = "새 비밀번호를 다시 입력해 주세요."
+    
     public static let uploadItemName = "상품명"
     public static let uploadItemPrice = "₩ 가격(필수)"
     public static let uploadItemMemo = "브랜드, 사이즈, 컬러 등 아이템 정보를 메모로 남겨보세요!😉"

--- a/Wishboard/global/UI/Namespace/StringEnum.swift
+++ b/Wishboard/global/UI/Namespace/StringEnum.swift
@@ -97,6 +97,7 @@ enum Title {
     public static let shoppingMallLink = "쇼핑몰 링크"
     public static let addItem = "아이템 추가"
     public static let modifyItem = "아이템 수정"
+    public static let memo = "메모"
     
     // MARK: Folder
     public static let folder = "폴더"

--- a/Wishboard/global/UI/Namespace/StringEnum.swift
+++ b/Wishboard/global/UI/Namespace/StringEnum.swift
@@ -33,7 +33,7 @@ enum Placeholder {
 
 enum ErrorMessage {
     // MARK: Authentication
-    public static let email = "이메일 주소를 정확하게 입력해 주세요."
+    public static let email = "이메일을 다시 확인해 주세요."
     public static let password = "8자리 이상의 영문자, 숫자, 특수 문자 조합으로 입력해 주세요."
     public static let passwordRewrite = "비밀번호가 일치하지 않아요!"
     public static let authcode = "인증코드를 다시 확인해 주세요."

--- a/Wishboard/global/UI/Namespace/UIColor.swift
+++ b/Wishboard/global/UI/Namespace/UIColor.swift
@@ -25,6 +25,7 @@ extension UIColor{
     static let green_700 = UIColor(red: 104/255, green: 235/255, blue: 114/255, alpha: 1)
     static let green_500 = UIColor(red: 149/255, green: 251/255, blue: 157/255, alpha: 1)
     static let green_200 = UIColor(red: 229/255, green: 254/255, blue: 231/255, alpha: 1)
+    static let green_alpha = UIColor(red: 104/255, green: 235/255, blue: 114/255, alpha: 0.15)
     
     // MARK: Pink
     static let pink_700 = UIColor(red: 250/255, green: 93/255, blue: 187/255, alpha: 1)

--- a/Wishboard/global/UI/UIButton.swift
+++ b/Wishboard/global/UI/UIButton.swift
@@ -83,6 +83,7 @@ extension UIButton {
         attText.foregroundColor = UIColor.gray_700
         config.attributedTitle = attText
         config.image = Image.noti
+        config.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0)
         
         self.configuration = config
     }

--- a/Wishboard/global/Util/BaseViewControllers/BaseViewController.swift
+++ b/Wishboard/global/Util/BaseViewControllers/BaseViewController.swift
@@ -105,7 +105,7 @@ class EtcButton: UIButton{
         self.titleLabel?.textAlignment = .center
         self.titleLabel?.setTypoStyleWithSingleLine(typoStyle: .SuitD2)
         self.setTitleColor(.gray_700, for: .normal)
-        self.titleEdgeInsets = UIEdgeInsets(top: 5, left: 0, bottom: 4, right: 0)
+        self.titleEdgeInsets = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: -4)
     }
     
     init(image: UIImage){

--- a/Wishboard/global/Util/BaseViewControllers/BottomSheetKeyboardViewController.swift
+++ b/Wishboard/global/Util/BaseViewControllers/BottomSheetKeyboardViewController.swift
@@ -117,7 +117,7 @@ class BottomSheetKeyboardViewController: BaseViewController {
             make.top.equalTo(textfield.snp.bottom).offset(6)
         }
         completeButton.snp.makeConstraints { make in
-            make.height.equalTo(44)
+            make.height.equalTo(48)
             make.leading.trailing.equalToSuperview().inset(16)
             make.top.equalTo(textfield.snp.bottom).offset(86)
         }

--- a/Wishboard/global/Util/PopUpViewControllers/PopUpDeleteUserViewController.swift
+++ b/Wishboard/global/Util/PopUpViewControllers/PopUpDeleteUserViewController.swift
@@ -32,14 +32,7 @@ class PopUpDeleteUserViewController: UIViewController {
         $0.setTypoStyleWithMultiLine(typoStyle: .SuitD2)
         $0.textColor = .gray_300
         $0.numberOfLines = 0
-        
-//        let attrString = NSMutableAttributedString(string: $0.text!)
-//        let paragraphStyle = NSMutableParagraphStyle()
-//        paragraphStyle.lineHeightMultiple = 1.18
-//        attrString.addAttribute(NSAttributedString.Key.paragraphStyle, value: paragraphStyle, range: NSMakeRange(0, attrString.length))
-//        $0.attributedText = attrString
-//
-//        $0.textAlignment = .center
+        $0.textAlignment = .center
     }
     let horizontalSeperator = UIView().then{
         $0.backgroundColor = .gray_100
@@ -85,6 +78,7 @@ class PopUpDeleteUserViewController: UIViewController {
         
         cancelBtn.addTarget(self, action: #selector(goBack), for: .touchUpInside)
         textField.addTarget(self, action: #selector(emailTextFieldEditingChanged(_:)), for: .allEditingEvents)
+        okBtn.addTarget(self, action: #selector(signOutButtonDidTap), for: .touchUpInside)
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -112,14 +106,18 @@ class PopUpDeleteUserViewController: UIViewController {
         self.dismiss(animated: false)
     }
     @objc func emailTextFieldEditingChanged(_ sender: UITextField) {
-        let text = sender.text ?? ""
-        if text != self.email {
-            self.errorMessage.isHidden = false
-            self.okBtn.isEnabled = false
+        errorMessage.isHidden = true
+    }
+    @objc func signOutButtonDidTap() {
+        print("tap")
+        let input = textField.text ?? ""
+        if input != self.email {
+            errorMessage.isHidden = false
         } else {
-            self.errorMessage.isHidden = true
-            self.okBtn.isEnabled = true
+            self.dismiss(animated: false)
+            MypageDataManager().deleteUserDataManager(self)
         }
+        UIDevice.vibrate()
     }
     // MARK: - Functions
     func setUpContent() {
@@ -143,7 +141,6 @@ class PopUpDeleteUserViewController: UIViewController {
             config.attributedTitle = attText
             
             $0.configuration = config
-            $0.isEnabled = false
         }
         textField.placeholder = self.placeholder
     }
@@ -262,4 +259,22 @@ extension PopUpDeleteUserViewController: UITextFieldDelegate {
         return true
     }
     
+}
+extension PopUpDeleteUserViewController {
+    // MARK: 회원 탈퇴 API
+    func deleteUserAPISuccess(_ result: APIModel<TokenResultModel>) {
+        // delete UserInfo
+        UserDefaults.standard.removeObject(forKey: "accessToken")
+        UserDefaults.standard.removeObject(forKey: "refreshToken")
+        UserDefaults.standard.removeObject(forKey: "email")
+        UserDefaults.standard.removeObject(forKey: "password")
+        UserDefaults.standard.removeObject(forKey: "isFirstLogin")
+        UserDefaults(suiteName: "group.gomin.Wishboard.Share")?.removeObject(forKey: "accessToken")
+        
+        let onboardingVC = OnBoardingViewController()
+        onboardingVC.deleteUser = true
+        self.navigationController?.pushViewController(onboardingVC, animated: true)
+        
+        print(result.message)
+    }
 }


### PR DESCRIPTION
## What is this PR? 🔍

## Key Changes 🔑
### 전체
- “로그인하기”와 “다음”버튼의 높이가 다릅니다! 모든 버튼의 높이를 확인해 주세요!
- 회원가입 > 이메일 입력 화면에서 상단 네비게이션바 내 요소들이 수직 가운데 정렬로 적용되었을까요? 전체적으로 상단 네비게이션바의 정렬을 확인해주세요~
- 전체적으로 텍스트 필드의 수직 여백이 12px이 적용되어있는지 확인해주세요!
- 전체적으로 텍스트 필드와 텍스트필드 하단에 나타나는 핑크 컬러의 디테일 텍스트의 간격이 6px인지 확인해 주세요!
### 로그인 및 회원가입
- 회원가입 > 비밀번호 입력 화면에서 가입하기 버튼과 이용약관 텍스트 간격이 넓어보입니다! 6px이 맞는지 확인해주세요~
- 일반 로그인 뷰에서 “비밀번호를 잊으셨나요?” 서체가 Suit B3인지 확인해주세요!
### 비밀번호 변경뷰
- 텍스트 필드의 힌트문구를 모두 확인해 주세요!
### 아이템 일반 등록 탭
- “복사한 링크로 아이템 정보를 불러올 수 있어요!" 텍스트 컬러가 green_700인지 확인해주세요!
- 우측 상단 저장버튼 크기와 서체를 확인해 주세요!
- 상품 알림 설정 모달에서 완료 버튼위로 보이는 “30분 전에 일정을 알려드려요. 시간은 30분 단위로 설정 가능해요!” 텍스트는 완료버튼을 기준으로 가운데 정렬이고, 완료버튼과의 간격은 6px입니다! 완료 버튼은 항상 초록색(활성화)처리해주세요~! 지금은 항상 비활성화 컬러로 보이네용!
### 링크 공유 팝업
- 전체적으로 뷰 크기, 배치 간격 확인해 주세요!
### 아이템 상세뷰
- 메모가 존재하는 경우 메모 타이틀이 보이도록 해주세요~
- 폴더 지정 시 폴더명 옆에 한칸 띄어쓰고 “>” 를 붙여주세요!
### 장바구니
- 아이템뷰 안에서 x버튼과 가격 텍스트 우측 정렬로 맞춰주세요! 수량 텍스트의 배치 간격을 확인해주세요!
### 마이페이지 탭
- 버전 네임 텍스트 크기는 버전 정보 텍스트 크기보다 작아야합니다! 두 텍스트에 서체가 제대로 적용되었는지 확인해주세요~
- 프로필 우측에 있는 편집 버튼의 크기와 서체를 확인해주세요~
- 탈퇴하기 알럿 > description 텍스트를 가운데 정렬로 적용해주시고, 경고 문구는 “이메일을 다시 확인해 주세요.”입니다! 탈퇴 버튼 클릭 후 이메일이 일치하지 않을 경우에만 경고 문구를 보여줍니다! 경고 문구가 보여진 이후 이메일을 수정한다면 경고문구는 사라져야합니다!
### 캘린더 알림
- 알림 있는 날짜에서 날짜 텍스트가 안보입니다! 연한 동그라미만 보여용!
- 상단의 년월, 요일 서체 확인해주세요~

## To Reviewers 📢
-
