### PR TITLE
QA v1.1.1 반영

### DIFF
--- a/Share Extension/Services/ShareDataManager.swift
+++ b/Share Extension/Services/ShareDataManager.swift
@@ -80,7 +80,7 @@ class ShareDataManager {
                         "item_notification_date" : itemNotificationDate,
                     ]    //PUT 함수로 전달할 String 데이터, 이미지 데이터는 제외하고 구성
         AF.upload(multipartFormData: { (multipart) in
-            if let imageData = photo.jpegData(compressionQuality: 0.8) {
+            if let imageData = photo.resizeImageIfNeeded().jpegData(compressionQuality: 1.0) {
                 multipart.append(imageData, withName: "item_img", fileName: "photo.jpg", mimeType: "image/jpeg")
                 //이미지 데이터를 POST할 데이터에 덧붙임
             }
@@ -134,7 +134,7 @@ class ShareDataManager {
                         "item_notification_date" : itemNotificationDate,
                     ]    //PUT 함수로 전달할 String 데이터, 이미지 데이터는 제외하고 구성
         AF.upload(multipartFormData: { (multipart) in
-            if let imageData = photo.jpegData(compressionQuality: 0.8) {
+            if let imageData = photo.resizeImageIfNeeded().jpegData(compressionQuality: 1.0) {
                 multipart.append(imageData, withName: "item_img", fileName: "photo.jpg", mimeType: "image/jpeg")
                 //이미지 데이터를 POST할 데이터에 덧붙임
             }
@@ -186,7 +186,7 @@ class ShareDataManager {
                         "item_memo" : itemMemo,
                     ]    //PUT 함수로 전달할 String 데이터, 이미지 데이터는 제외하고 구성
         AF.upload(multipartFormData: { (multipart) in
-            if let imageData = photo.jpegData(compressionQuality: 0.8) {
+            if let imageData = photo.resizeImageIfNeeded().jpegData(compressionQuality: 1.0) {
                 multipart.append(imageData, withName: "item_img", fileName: "photo.jpg", mimeType: "image/jpeg")
                 //이미지 데이터를 POST할 데이터에 덧붙임
             }
@@ -237,7 +237,7 @@ class ShareDataManager {
                         "item_memo" : itemMemo,
                     ]    //PUT 함수로 전달할 String 데이터, 이미지 데이터는 제외하고 구성
         AF.upload(multipartFormData: { (multipart) in
-            if let imageData = photo.jpegData(compressionQuality: 0.8) {
+            if let imageData = photo.resizeImageIfNeeded().jpegData(compressionQuality: 1.0) {
                 multipart.append(imageData, withName: "item_img", fileName: "photo.jpg", mimeType: "image/jpeg")
                 //이미지 데이터를 POST할 데이터에 덧붙임
             }

--- a/Wishboard.xcodeproj/project.pbxproj
+++ b/Wishboard.xcodeproj/project.pbxproj
@@ -92,6 +92,8 @@
 		2364B7A829D40F8F006459EF /* ModifyPasswordView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2364B7A729D40F8F006459EF /* ModifyPasswordView.swift */; };
 		2364B7AA29D41E1F006459EF /* TitleCenterViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23F07F4328E7D5930012D77D /* TitleCenterViewController.swift */; };
 		236AC9F0291A6AB700E1474C /* Storage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 236AC9EF291A6AB700E1474C /* Storage.swift */; };
+		236EE70B2A88B5F00070437D /* UIImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 236EE70A2A88B5F00070437D /* UIImage.swift */; };
+		236EE70C2A88BBA10070437D /* UIImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 236EE70A2A88B5F00070437D /* UIImage.swift */; };
 		236FE90428DF7BE0006142DB /* SUIT-Bold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 236FE90128DF7BE0006142DB /* SUIT-Bold.ttf */; };
 		236FE90628DF7BE0006142DB /* SUIT-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 236FE90228DF7BE0006142DB /* SUIT-Regular.ttf */; };
 		236FE91028DF8385006142DB /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 23DC04B628C58B5500ABB0CF /* Assets.xcassets */; };
@@ -336,6 +338,7 @@
 		2364B7A329D40F61006459EF /* ModifyPasswordViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModifyPasswordViewController.swift; sourceTree = "<group>"; };
 		2364B7A729D40F8F006459EF /* ModifyPasswordView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModifyPasswordView.swift; sourceTree = "<group>"; };
 		236AC9EF291A6AB700E1474C /* Storage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Storage.swift; sourceTree = "<group>"; };
+		236EE70A2A88B5F00070437D /* UIImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIImage.swift; sourceTree = "<group>"; };
 		236FE90128DF7BE0006142DB /* SUIT-Bold.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SUIT-Bold.ttf"; sourceTree = "<group>"; };
 		236FE90228DF7BE0006142DB /* SUIT-Regular.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SUIT-Regular.ttf"; sourceTree = "<group>"; };
 		236FE94128DF888A006142DB /* FolderCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FolderCollectionViewCell.swift; sourceTree = "<group>"; };
@@ -1098,6 +1101,7 @@
 				23D5518A28C6B45C00D81B5F /* String.swift */,
 				239422E5292FEFCB0024CEBD /* Optional.swift */,
 				239F93672939322C008AC5AB /* Bundle.swift */,
+				236EE70A2A88B5F00070437D /* UIImage.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -1790,6 +1794,7 @@
 				236309522919085600E38885 /* Vibrate.swift in Sources */,
 				236FE91828DF8512006142DB /* SetLottie.swift in Sources */,
 				231B581028E8A33C0030D33E /* BaseViewController.swift in Sources */,
+				236EE70C2A88BBA10070437D /* UIImage.swift in Sources */,
 				230DBFA828E106EE00E9AED6 /* ShareView.swift in Sources */,
 				230180E628E50B7C001034FC /* FolderDataManager.swift in Sources */,
 				23A48E7128E92E7D00FD77A7 /* NetworkCheck.swift in Sources */,
@@ -1874,6 +1879,7 @@
 				2374789A28D1DB2900CF941A /* CheckNotch.swift in Sources */,
 				2339D4FC28E3CD3800E636FD /* FolderModel.swift in Sources */,
 				2395FFF42902E1C1005A8D8F /* UploadItemTextfieldTableViewCell.swift in Sources */,
+				236EE70B2A88B5F00070437D /* UIImage.swift in Sources */,
 				23D0824E28E4DC3A00CE541E /* ItemDataManager.swift in Sources */,
 				230A3F5928E4B5CA00966682 /* NotificationDataManager.swift in Sources */,
 				2339D4FF28E3CFF900E636FD /* FolderInput.swift in Sources */,
@@ -2063,7 +2069,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "Share Extension/Share Extension.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 202306151456;
+				CURRENT_PROJECT_VERSION = 202308082122;
 				DEVELOPMENT_TEAM = B974XY47GZ;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Share Extension/Info.plist";
@@ -2092,7 +2098,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "Share Extension/Share Extension.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 202306151456;
+				CURRENT_PROJECT_VERSION = 202308082122;
 				DEVELOPMENT_TEAM = B974XY47GZ;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Share Extension/Info.plist";
@@ -2241,7 +2247,7 @@
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = YES;
 				CODE_SIGN_ENTITLEMENTS = Wishboard/Wishboard.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 202306151456;
+				CURRENT_PROJECT_VERSION = 202308082122;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_TEAM = B974XY47GZ;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -2277,7 +2283,7 @@
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = YES;
 				CODE_SIGN_ENTITLEMENTS = Wishboard/Wishboard.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 202306151456;
+				CURRENT_PROJECT_VERSION = 202308082122;
 				DEVELOPMENT_TEAM = B974XY47GZ;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Wishboard/Info.plist;

--- a/Wishboard/domain/Services/Authentication/UserRouter.swift
+++ b/Wishboard/domain/Services/Authentication/UserRouter.swift
@@ -88,7 +88,7 @@ extension UserRouter{
         }
 
         if let image = param.photo {
-            let imageData = image.jpegData(compressionQuality: 0.5) ?? Data()
+            let imageData = image.resizeImageIfNeeded().jpegData(compressionQuality: 1.0) ?? Data()
             imageMultipartFormData = MultipartFormData(provider: .data(imageData), name: "profile_img", fileName: "profileImg.jpeg", mimeType: "image/jpeg")
             if let imageMultipartFormData = imageMultipartFormData {
                 formData.append(imageMultipartFormData)

--- a/Wishboard/domain/Services/Item/ItemRouter.swift
+++ b/Wishboard/domain/Services/Item/ItemRouter.swift
@@ -84,8 +84,8 @@ extension ItemRouter{
             itemNotificationDateData = MultipartFormData(provider: .data(itemNotificationDate.data(using: String.Encoding.utf8) ?? Data()), name: "item_notification_date")
         }
 
-        let imageData = param.photo.jpegData(compressionQuality: 0.5) ?? Data()
-        let imageMultipartFormData = MultipartFormData(provider: .data(imageData), name: "item_img", fileName: "itemmm.jpeg", mimeType: "image/jpeg")
+        let imageData = param.photo.resizeImageIfNeeded().jpegData(compressionQuality: 1.0) ?? Data()
+        let imageMultipartFormData = MultipartFormData(provider: .data(imageData), name: "item_img", fileName: "item.jpeg", mimeType: "image/jpeg")
         
         var formData: [Moya.MultipartFormData] = [imageMultipartFormData]
         formData.append(itemNameData)

--- a/Wishboard/domain/ViewControllers/Item/UploadItem/NotificationSettingViewController.swift
+++ b/Wishboard/domain/ViewControllers/Item/UploadItem/NotificationSettingViewController.swift
@@ -100,13 +100,13 @@ class NotificationSettingViewController: UIViewController {
         }
         notificationPickerView.snp.makeConstraints { make in
             make.leading.trailing.equalToSuperview().inset(16)
-            make.top.equalTo(titleLabel.snp.bottom).offset(51.5)
-            make.height.equalTo(100)
+            make.top.equalTo(titleLabel.snp.bottom).offset(45)
+            make.height.equalTo(34 * 3 + 20)
         }
         completeButton.snp.makeConstraints { make in
             make.height.equalTo(48)
             make.leading.trailing.equalToSuperview().inset(16)
-            make.top.equalToSuperview().offset(235)
+            make.bottom.equalToSuperview().offset(-34)
         }
         message.snp.makeConstraints { make in
             make.centerX.equalToSuperview()
@@ -135,13 +135,20 @@ class NotificationSettingViewController: UIViewController {
 // MARK: - Picker delegate
 extension NotificationSettingViewController: UIPickerViewDelegate, UIPickerViewDataSource {
     func numberOfComponents(in pickerView: UIPickerView) -> Int {
+        /*
+         첫번째: 상품 알림 유형 (재입고, 오픈 등..)
+         두번째: 날짜
+         세번째: 시
+         네번째: 땡땡 (:)
+         다섯번째: 분
+         */
         return 5
     }
-    
+    /// row 당 아이템 개수
     func pickerView(_ pickerView: UIPickerView, numberOfRowsInComponent component: Int) -> Int {
         switch component {
         case 0:
-            return 5
+            return 6
         case 1:
             return 90
         case 2:
@@ -153,7 +160,7 @@ extension NotificationSettingViewController: UIPickerViewDelegate, UIPickerViewD
         }
         
     }
-    
+    /// row 당 아이템 타이틀
     func pickerView(_ pickerView: UIPickerView, titleForRow row: Int, forComponent component: Int) -> String? {
         switch component {
         case 0:
@@ -169,11 +176,11 @@ extension NotificationSettingViewController: UIPickerViewDelegate, UIPickerViewD
         }
         
     }
-    // font 적용
+    /// font 적용
     func pickerView(_ pickerView: UIPickerView, viewForRow row: Int, forComponent component: Int, reusing view: UIView?) -> UIView {
         var label = UILabel()
         if let v = view as? UILabel { label = v }
-        label.setTypoStyleWithSingleLine(typoStyle: .SuitB3)
+        label.setTypoStyleWithSingleLine(typoStyle: .SuitD2)
         label.textAlignment = .center
         
         switch component {
@@ -191,6 +198,7 @@ extension NotificationSettingViewController: UIPickerViewDelegate, UIPickerViewD
         
         return label
     }
+    /// 열 가로길이
     func pickerView(_ pickerView: UIPickerView, widthForComponent component: Int) -> CGFloat {
         switch component {
         case 0:
@@ -205,6 +213,11 @@ extension NotificationSettingViewController: UIPickerViewDelegate, UIPickerViewD
             return 5
         }
     }
+    /// 행 세로길이
+    func pickerView(_ pickerView: UIPickerView, rowHeightForComponent component: Int) -> CGFloat {
+        return 34
+    }
+    /// 행 선택 이벤트
     func pickerView(_ pickerView: UIPickerView, didSelectRow row: Int, inComponent component: Int) {
         switch component {
         case 0:

--- a/Wishboard/domain/Views/Authentication/Login/LoginView.swift
+++ b/Wishboard/domain/Views/Authentication/Login/LoginView.swift
@@ -48,7 +48,7 @@ class LoginView: UIView {
     }
     // 비밀번호를 잊으셨나요?
     let lostPasswordButtonKeyboard = UIButton().then{
-        $0.setUnderline(Button.lostPassword, UIColor.systemGray)
+        $0.setUnderline(Button.lostPassword, .gray_300, TypoStyle.SuitB3.font)
     }
     
     // MARK: - Functions

--- a/Wishboard/global/Util/BaseViewControllers/BottomSheetKeyboardViewController.swift
+++ b/Wishboard/global/Util/BaseViewControllers/BottomSheetKeyboardViewController.swift
@@ -120,6 +120,7 @@ class BottomSheetKeyboardViewController: BaseViewController {
             make.height.equalTo(48)
             make.leading.trailing.equalToSuperview().inset(16)
             make.top.equalTo(textfield.snp.bottom).offset(86)
+            make.bottom.equalToSuperview().offset(-34)
         }
     }
     

--- a/Wishboard/global/Util/Extensions/UIImage.swift
+++ b/Wishboard/global/Util/Extensions/UIImage.swift
@@ -1,0 +1,56 @@
+//
+//  UIImage.swift
+//  Wishboard
+//
+//  Created by gomin on 2023/08/13.
+//
+
+import Foundation
+import UIKit
+
+extension UIImage {
+    /// 가로와 세로의 비율을 유지한 채로 긴 쪽의 길이를 720으로 유지
+    func resizeImageIfNeeded() -> UIImage {
+        let targetSize = CGSize(width: 720, height: 720)
+        
+        guard let cgImage = self.cgImage else {
+            return self
+        }
+        
+        let size = CGSize(width: CGFloat(cgImage.width), height: CGFloat(cgImage.height))
+        
+        if size.width <= targetSize.width && size.height <= targetSize.height {
+            // 이미지가 작은 경우 리사이징하지 않고 그대로 반환
+            return self
+        }
+        
+        var newSize = size
+        if size.width > size.height {
+            newSize.height = targetSize.height * size.height / size.width
+            newSize.width = targetSize.width
+        } else {
+            newSize.width = targetSize.width * size.width / size.height
+            newSize.height = targetSize.height
+        }
+        
+        let colorSpace = CGColorSpaceCreateDeviceRGB()
+        let context = CGContext(data: nil, width: Int(newSize.width), height: Int(newSize.height), bitsPerComponent: 8, bytesPerRow: 0, space: colorSpace, bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue)
+        
+        context?.interpolationQuality = .high
+        context?.draw(cgImage, in: CGRect(origin: .zero, size: newSize))
+        
+        if let resizedImage = context?.makeImage().flatMap({ UIImage(cgImage: $0) }) {
+            return resizedImage
+        } else {
+            return self
+        }
+    }
+    /// 이미지
+    func printImageDimensions(_ image: UIImage) {
+        let width = image.size.width
+        let height = image.size.height
+        
+        print("Image Width: \(width)")
+        print("Image Height: \(height)")
+    }
+}

--- a/Wishboard/global/Util/SetNotificationDate.swift
+++ b/Wishboard/global/Util/SetNotificationDate.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 class SetNotificationDate {
-    let notificationData = ["재입고", "오픈", "프리오더", "세일 시작", "세일 마감"]
+    let notificationData = ["재입고", "오픈", "프리오더", "세일 시작", "세일 마감", "리마인드"]
     var dateData: Array<String>! = []
     var hourData: Array<String>! = []
     var minuteData: Array<String>! = []


### PR DESCRIPTION
## What is this PR? 🔍
QA v1.1.1 반영
## Key Changes 🔑
1. 서버로 이미지 전송 시 이미지 리사이징
   - 로직은 다음과 같습니다.
       - 기존 : 사진 선택 -> 0.8 또는 0.5 화질로 낮춤 -> jpeg 로 전환
       - 현재 : 사진 선택 -> 사진의 가로 또는 세로가 720보다 크다면 -> 긴 쪽을 720로 맞추되 가로세로 비율은 맞춤 -> 화질은 낮추지 않고 jpeg로 전환
       - 만약 사진의 크기가 720*720 보다 작다면 해당 로직 진행하지 않습니다.
       - UIImage의 Extension으로 메서드 구현
       - 해당 메서드가 적용된 기능은 다음과 같습니다
          - 아이템 일반 등록
          - 링크 공유 등록
          - 프로필 편집
2. 상품 알림 설정 > 날짜 Picker 커스텀
    - row 당 세로길이 설정 (34)
    - 상품 유형 6가지로 재설정

## To Reviewers 📢
- 버튼 > 로띠 문제만 해결하면 될 것 같습니다.
- tokenInterceptor 적용을 하고 싶군요 ... 이 부분은 리팩토링 시에!
